### PR TITLE
Save and load ResidualMatrices via type hints. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     HDF5Array
 Suggests:
     BiocSingular,
+    ResidualMatrix,
     BiocStyle,
     testthat,
     rmarkdown,

--- a/R/base-save.R
+++ b/R/base-save.R
@@ -151,6 +151,29 @@ setMethod("saveDelayedObject", "ANY", function(x, file, name) {
         write_string_scalar(file, name, "left_orientation", "N");
         saveDelayedObject(x@components, file, paste0(name, "/right_seed"))
         write_string_scalar(file, name, "right_orientation", "T");
+
+    } else if (is(x, "ResidualMatrixSeed")) {
+        h5createGroup(file, name)
+        write_string_scalar(file, name, "r_type_hint", "residual matrix");
+
+        if (x@transposed) {
+            .label_group_operation(file, name, 'transpose')
+            h5write(x@perm - 1L, file, file.path(name, "permutation"))
+            name <- paste0(name, "/seed")
+            h5createGroup(file, name)
+        }
+
+        .label_group_operation(file, name, 'binary arithmetic')
+        write_string_scalar(file, name, "method", "-")
+        saveDelayedObject(x@.matrix, file, paste0(name, "/left"))
+
+        name <- paste0(name, "/right")
+        .label_group_operation(file, name, 'matrix product')
+        saveDelayedObject(x@Q, file, paste0(name, "/left_seed"))
+        write_string_scalar(file, name, "left_orientation", "N");
+        saveDelayedObject(x@Qty, file, paste0(name, "/right_seed"))
+        write_string_scalar(file, name, "right_orientation", "N");
+
     } else {
         pkg <- attr(class(x), "package")
         failed <- TRUE

--- a/R/base-save.R
+++ b/R/base-save.R
@@ -156,18 +156,22 @@ setMethod("saveDelayedObject", "ANY", function(x, file, name) {
         h5createGroup(file, name)
         write_string_scalar(file, name, "r_type_hint", "residual matrix");
 
+        # Mimic a transposition operation.
         if (x@transposed) {
             .label_group_operation(file, name, 'transpose')
-            h5write(x@perm - 1L, file, file.path(name, "permutation"))
+            h5write(c(1L, 0L), file, file.path(name, "permutation"))
             name <- paste0(name, "/seed")
             h5createGroup(file, name)
         }
 
+        # Mimic a binary subtraction.
         .label_group_operation(file, name, 'binary arithmetic')
         write_string_scalar(file, name, "method", "-")
         saveDelayedObject(x@.matrix, file, paste0(name, "/left"))
 
+        # Mimic a matrix product.
         name <- paste0(name, "/right")
+        h5createGroup(file, name)
         .label_group_operation(file, name, 'matrix product')
         saveDelayedObject(x@Q, file, paste0(name, "/left_seed"))
         write_string_scalar(file, name, "left_orientation", "N");
@@ -219,4 +223,30 @@ setMethod("saveDelayedObject", "ANY", function(x, file, name) {
     }
 
     BiocSingular::LowRankMatrix(L, R)
+}
+
+#' @importFrom rhdf5 h5readAttributes
+.load_residual_matrix <- function(file, name) {
+    if (missing(file)) {
+        return(length(find.package("ResidualMatrix")) > 0);
+    }
+
+    attrs <- h5readAttributes(file, name)
+    transposed <- FALSE
+    if (attrs$delayed_operation == "transpose") {
+        transposed <- TRUE
+        name <- paste0(name, "/seed")
+    }
+
+    .matrix <- .dispatch_loader(file, paste0(name, "/left"))
+    .matrix <- .matrix@seed # TODO: fix this in ResidualMatrix so that subtraction works for arbitrary DelayedMatrix objects.
+
+    Q <- .dispatch_loader(file, paste0(name, "/right/left_seed"))
+    Qty <- .dispatch_loader(file, paste0(name, "/right/right_seed"))
+
+    if (!isNamespaceLoaded("ResidualMatrix")) {
+        loadNamespace("ResidualMatrix")
+    }
+    seed <- new("ResidualMatrixSeed", .matrix = .matrix, Q = as.matrix(Q), Qty = as.matrix(Qty), transposed = transposed)
+    DelayedArray(seed)
 }

--- a/R/loadDelayed.R
+++ b/R/loadDelayed.R
@@ -41,7 +41,15 @@ loadDelayed <- function(file, path="delayed") {
             }
         }
 
-        FUN <- known.env$operations[[attrs$delayed_operation]]
+        key <- attrs$delayed_operation
+        if (h5exists(file, path, "r_type_hint")) {
+            altkey <- h5read(file, path, "r_type_hint")
+            if (known.env$operations[[altkey]]()) {
+                key <- altkey
+            }
+        }
+
+        FUN <- known.env$operations[[key]]
         if (is.null(FUN)) {
             stop("unknown operation type '", attrs$delayed_operation, "'")
         }

--- a/R/loadDelayed.R
+++ b/R/loadDelayed.R
@@ -42,9 +42,11 @@ loadDelayed <- function(file, path="delayed") {
         }
 
         key <- attrs$delayed_operation
+
+        # Check if there's a R type hint that we can use.
         if (h5exists(file, path, "r_type_hint")) {
-            altkey <- h5read(file, path, "r_type_hint")
-            if (known.env$operations[[altkey]]()) {
+            altkey <- h5read(file, paste0(path, "/r_type_hint"))
+            if (altkey %in% names(known.env$operations) && known.env$operations[[altkey]]()) {
                 key <- altkey
             }
         }
@@ -94,7 +96,8 @@ known.env$operations <- list(
     `unary logic`=.load_delayed_unary_iso,
     `unary math`=.load_delayed_unary_iso,
     `unary special check`=.load_delayed_unary_iso,
-    `matrix product`=.load_matrix_product
+    `matrix product`=.load_matrix_product,
+    `residual matrix`=.load_residual_matrix
 )
 
 known.env$arrays <- list(

--- a/tests/testthat/test-other.R
+++ b/tests/testthat/test-other.R
@@ -123,3 +123,39 @@ test_that("saving of a LowRankMatrix works correctly", {
     out <- loadDelayed(temp)
     expect_identical(thing, out)
 })
+
+test_that("saving of a ResidualMatrix works correctly", {
+    y <- rsparsematrix(80, 50, 0.5)
+    design <- model.matrix(~gl(8, 10))
+    thing <- ResidualMatrix::ResidualMatrix(y, design=design)
+
+    # Round-trips properly.
+    temp <- tempfile()
+    saveDelayed(thing, temp)
+    out <- loadDelayed(temp)
+    expect_identical(thing, out)
+    expect_s4_class(out, "ResidualMatrix")
+
+    # Works when transposed.
+    thing2 <- t(thing)
+    temp2 <- tempfile()
+    saveDelayed(thing2, temp2)
+    out <- loadDelayed(temp2)
+    expect_identical(thing2, out)
+    expect_s4_class(out, "ResidualMatrix")
+
+    # Same result if we ignore the type hint.
+    current <- knownOperations()
+    current[["residual matrix"]] <- NULL
+    old <- knownOperations(current)
+    on.exit(knownOperations(old))
+
+    out <- loadDelayed(temp)
+    expect_false(is(out, "ResidualMatrix"))
+    expect_identical(unname(as.matrix(thing)), unname(as.matrix(out)))
+            
+    out <- loadDelayed(temp2)
+    expect_false(is(out, "ResidualMatrix"))
+    expect_identical(unname(as.matrix(thing2)), unname(as.matrix(out)))
+})
+


### PR DESCRIPTION
This save the ResidualMatrix as a series of delayed operations,
with an extra R-specific type hint to load it as a ResidualMatrix
(rather than a standard DelayedMatrix) if the package is available.